### PR TITLE
[BE] 아이디 찾기

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
+    implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 
     // lombok
     compileOnly 'org.projectlombok:lombok'

--- a/src/main/java/com/novelpark/application/auth/AuthService.java
+++ b/src/main/java/com/novelpark/application/auth/AuthService.java
@@ -62,6 +62,6 @@ public class AuthService {
             String.format("%s 이메일을 가진 사용자가 존재하지 않습니다.", email)
         ));
 
-    mailService.sendFindLoginFormEmail(loginId, email);
+    mailService.sendFindLoginIdMail(loginId, email);
   }
 }

--- a/src/main/java/com/novelpark/application/mail/MailService.java
+++ b/src/main/java/com/novelpark/application/mail/MailService.java
@@ -20,7 +20,7 @@ public class MailService {
   private final JavaMailSender mailSender;
 
   @Async("mailThreadExecutor")
-  public void sendFindLoginFormEmail(final String loginId, final String receiverEmail) {
+  public void sendFindLoginIdMail(final String loginId, final String receiverEmail) {
     Context context = new Context();
     context.setVariable("head", "Novel Park 아이디 찾가");
     context.setVariable("body", String.format("귀하의 아이디는 %s 입니다.", loginId));

--- a/src/main/java/com/novelpark/application/mail/MailService.java
+++ b/src/main/java/com/novelpark/application/mail/MailService.java
@@ -1,0 +1,45 @@
+package com.novelpark.application.mail;
+
+import com.novelpark.exception.ErrorCode;
+import com.novelpark.exception.InternalServerException;
+import javax.mail.MessagingException;
+import javax.mail.internet.MimeMessage;
+import lombok.RequiredArgsConstructor;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.thymeleaf.TemplateEngine;
+import org.thymeleaf.context.Context;
+
+@RequiredArgsConstructor
+@Service
+public class MailService {
+
+  private final TemplateEngine templateEngine;
+  private final JavaMailSender mailSender;
+
+  @Async("mailThreadExecutor")
+  public void sendFindLoginFormEmail(final String loginId, final String receiverEmail) {
+    Context context = new Context();
+    context.setVariable("head", "Novel Park 아이디 찾가");
+    context.setVariable("body", String.format("귀하의 아이디는 %s 입니다.", loginId));
+
+    String message = templateEngine.process("email.html", context);
+    sendMail("[Novel Park] 귀하의 아이디 찾기에 대한 메일입니다.", message, receiverEmail);
+  }
+
+  private void sendMail(final String subject, final String htmlText, final String receiverEmail) {
+    try {
+      MimeMessage mail = mailSender.createMimeMessage();
+      MimeMessageHelper mimeMessageHelper = new MimeMessageHelper(mail, true, "UTF-8");
+      mimeMessageHelper.setTo(receiverEmail);
+      mimeMessageHelper.setSubject(subject);
+      mimeMessageHelper.setText(htmlText, true);
+
+      mailSender.send(mail);
+    } catch (MessagingException ex) {
+      throw new InternalServerException(ErrorCode.MAIL_SEND_FAIL);
+    }
+  }
+}

--- a/src/main/java/com/novelpark/config/AsyncConfig.java
+++ b/src/main/java/com/novelpark/config/AsyncConfig.java
@@ -1,0 +1,19 @@
+package com.novelpark.config;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadPoolExecutor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.CustomizableThreadFactory;
+
+@EnableAsync
+@Configuration(proxyBeanMethods = false)
+public class AsyncConfig {
+
+  @Bean(name = "mailThreadExecutor")
+  public ThreadPoolExecutor mailExecutor() {
+    return (ThreadPoolExecutor) Executors.newFixedThreadPool(3,
+        new CustomizableThreadFactory("mail-thread-group"));
+  }
+}

--- a/src/main/java/com/novelpark/config/AsyncConfig.java
+++ b/src/main/java/com/novelpark/config/AsyncConfig.java
@@ -13,7 +13,7 @@ public class AsyncConfig {
 
   @Bean(name = "mailThreadExecutor")
   public ThreadPoolExecutor mailExecutor() {
-    return (ThreadPoolExecutor) Executors.newFixedThreadPool(3,
+    return (ThreadPoolExecutor) Executors.newFixedThreadPool(2,
         new CustomizableThreadFactory("mail-thread-group"));
   }
 }

--- a/src/main/java/com/novelpark/domain/member/MemberRepository.java
+++ b/src/main/java/com/novelpark/domain/member/MemberRepository.java
@@ -2,10 +2,18 @@ package com.novelpark.domain.member;
 
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
   Optional<Member> findByLoginId(String loginId);
 
   boolean existsByLoginId(String loginId);
+
+  @Query("SELECT m.loginId FROM Member m WHERE m.email = :email AND m.name = :name")
+  Optional<String> findLoginIdByEmailAndName(
+      @Param("email") String email,
+      @Param("name") String name
+  );
 }

--- a/src/main/java/com/novelpark/exception/ErrorCode.java
+++ b/src/main/java/com/novelpark/exception/ErrorCode.java
@@ -13,7 +13,10 @@ public enum ErrorCode {
 
   // IMAGE
   INVALID_IMAGE("이미지 업로드에 실패했습니다."),
-  INVALID_FILE_EXTENSION("이미지 파일의 확장자는 png, jpg, jpeg, gif만 가능합니다.");
+  INVALID_FILE_EXTENSION("이미지 파일의 확장자는 png, jpg, jpeg, gif만 가능합니다."),
+
+  // MAIL
+  MAIL_SEND_FAIL("메일 전송에 실패했습니다.");
 
   private final String message;
 

--- a/src/main/java/com/novelpark/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/novelpark/exception/GlobalExceptionHandler.java
@@ -8,13 +8,18 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
-	@ExceptionHandler(BadRequestException.class)
-	public ResponseEntity<ErrorResponse> handleBadRequestException(BadRequestException ex) {
-		return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ErrorResponse.from(ex));
-	}
+  @ExceptionHandler(BadRequestException.class)
+  public ResponseEntity<ErrorResponse> handleBadRequestException(BadRequestException ex) {
+    return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ErrorResponse.from(ex));
+  }
 
-	@ExceptionHandler(InternalServerException.class)
-	public ResponseEntity<ErrorResponse> handleInternalServerException(InternalServerException ex) {
-		return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(ErrorResponse.from(ex));
-	}
+  @ExceptionHandler(NotFoundException.class)
+  public ResponseEntity<ErrorResponse> handleNotFoundException(NotFoundException ex) {
+    return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ErrorResponse.from(ex));
+  }
+
+  @ExceptionHandler(InternalServerException.class)
+  public ResponseEntity<ErrorResponse> handleInternalServerException(InternalServerException ex) {
+    return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(ErrorResponse.from(ex));
+  }
 }

--- a/src/main/java/com/novelpark/exception/NotFoundException.java
+++ b/src/main/java/com/novelpark/exception/NotFoundException.java
@@ -1,0 +1,12 @@
+package com.novelpark.exception;
+
+public class NotFoundException extends NovelParkException {
+
+    public NotFoundException(ErrorCode errorCode, String message) {
+        super(errorCode, message);
+    }
+
+    public NotFoundException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/novelpark/presentation/AuthController.java
+++ b/src/main/java/com/novelpark/presentation/AuthController.java
@@ -1,58 +1,70 @@
 package com.novelpark.presentation;
 
+import com.novelpark.application.auth.AuthService;
 import com.novelpark.application.constant.AuthConstant;
 import com.novelpark.presentation.dto.request.auth.LoginRequest;
+import com.novelpark.presentation.dto.request.auth.SignupRequest;
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
 import javax.validation.Valid;
-
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
-
-import com.novelpark.application.auth.AuthService;
-import com.novelpark.presentation.dto.request.auth.SignupRequest;
-
-import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 @RequestMapping("/api")
 @RestController
 public class AuthController {
 
-	private final AuthService authService;
+  private final AuthService authService;
 
-	@PostMapping("/login")
-	public ResponseEntity<Void> login(@Valid @RequestBody LoginRequest loginReq, HttpServletRequest servletReq, HttpServletResponse servletRes) {
-		final long memberSeq = authService.login(loginReq);
+  @PostMapping("/login")
+  public ResponseEntity<Void> login(
+      @Valid @RequestBody LoginRequest loginReq,
+      HttpServletRequest servletReq,
+      HttpServletResponse servletRes
+  ) {
+    final long memberSeq = authService.login(loginReq);
 
-		// 세션 생성
-		HttpSession session = servletReq.getSession(true);
-		session.setAttribute(AuthConstant.SESSION_ATTR_NAME, memberSeq);
-		session.setMaxInactiveInterval(AuthConstant.SESSION_TIMEOUT_IN_SECONDS);
+    // 세션 생성
+    HttpSession session = servletReq.getSession(true);
+    session.setAttribute(AuthConstant.SESSION_ATTR_NAME, memberSeq);
+    session.setMaxInactiveInterval(AuthConstant.SESSION_TIMEOUT_IN_SECONDS);
 
-		// 쿠키 생성 및 응답 헤더에 추가
-		Cookie sessionCookie = new Cookie(AuthConstant.JSESSIONID, session.getId());
-		sessionCookie.setHttpOnly(true);
-		servletRes.addCookie(sessionCookie);
+    // 쿠키 생성 및 응답 헤더에 추가
+    Cookie sessionCookie = new Cookie(AuthConstant.JSESSIONID, session.getId());
+    sessionCookie.setHttpOnly(true);
+    servletRes.addCookie(sessionCookie);
 
-		return ResponseEntity.ok().build();
-	}
+    return ResponseEntity.ok().build();
+  }
 
-	@PostMapping(value = "/signup", consumes = {
-		MediaType.APPLICATION_JSON_VALUE,
-		MediaType.MULTIPART_FORM_DATA_VALUE
-	})
-	public ResponseEntity<Void> signup(@Valid @RequestPart SignupRequest request, @RequestPart MultipartFile image) {
-		authService.signup(request, image);
-		return ResponseEntity.status(HttpStatus.CREATED).build();
-	}
+  @PostMapping(value = "/signup", consumes = {
+      MediaType.APPLICATION_JSON_VALUE,
+      MediaType.MULTIPART_FORM_DATA_VALUE
+  })
+  public ResponseEntity<Void> signup(
+      @Valid @RequestPart SignupRequest request,
+      @RequestPart MultipartFile image
+  ) {
+    authService.signup(request, image);
+    return ResponseEntity.status(HttpStatus.CREATED).build();
+  }
+
+  @GetMapping("/id")
+  public ResponseEntity<Void> findLoginId(@RequestParam String name, @RequestParam String email) {
+    authService.findLoginId(name, email);
+    return ResponseEntity.ok().build();
+  }
 }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -12,6 +12,19 @@ spring:
         show_sql: true
         format_sql: true
 
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: ${mail.username}
+    password: ${mail.password}
+    properties:
+      mail:
+        smtp:
+          auth: true
+          timeout: 5000
+          starttls:
+            enable: true
+
 cloud:
   aws:
     credentials:

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -12,6 +12,18 @@ spring:
         show_sql: true
         format_sql: true
 
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: username
+    password: password
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
+
 cloud:
   aws:
     credentials:

--- a/src/main/resources/templates/email.html
+++ b/src/main/resources/templates/email.html
@@ -1,0 +1,53 @@
+<!DOCTYPE HTML>
+<html lang="kr" xmlns="http://www.w3.org/1999/xhtml" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+    <title>Novel Park 아이디 찾기</title>
+</head>
+<body>
+<table
+        align="center"
+        cellpadding="0"
+        cellspacing="0"
+        style="
+            border-collapse: collapse;
+            width: 100%;
+            margin: 0;
+            padding: 0;
+            color: #333333;
+        "
+>
+    <tr>
+        <td align="center">
+            <h1 class="title"><span th:text="${head}"></span></h1>
+        </td>
+    </tr>
+    <tr>
+        <td align="center" style="padding: 60px 0 240px 0">
+            <h3 class="title"><span th:text="${body}"></span></h3>
+        </td>
+    </tr>
+    <tr>
+        <td>
+            <table
+                    bgcolor="#fafafa"
+                    width="100%"
+                    style="width: 100%; padding-left: 20px"
+            >
+                <tr>
+                    <td>
+                        <p>Novel park</p>
+                    </td>
+                </tr>
+                <tr>
+                    <td>
+                        <p>© Novel park all rights reserved</p>
+                    </td>
+                </tr>
+            </table>
+        </td>
+    </tr>
+</table>
+</body>
+</html>

--- a/src/test/java/com/novelpark/acceptance/AuthAcceptanceTest.java
+++ b/src/test/java/com/novelpark/acceptance/AuthAcceptanceTest.java
@@ -124,7 +124,7 @@ public class AuthAcceptanceTest {
     void givenNameAndEmail_whenFindLoginId_thenSuccess() throws Exception {
       // given
       given(s3Uploader.uploadImageFile(any(ImageFile.class))).willReturn("image resource url");
-      willDoNothing().given(mailService).sendFindLoginFormEmail(anyString(), anyString());
+      willDoNothing().given(mailService).sendFindLoginIdMail(anyString(), anyString());
 
       // 회원가입
       RestAssured

--- a/src/test/java/com/novelpark/acceptance/AuthAcceptanceTest.java
+++ b/src/test/java/com/novelpark/acceptance/AuthAcceptanceTest.java
@@ -2,11 +2,14 @@ package com.novelpark.acceptance;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.any;
+import static org.mockito.BDDMockito.anyString;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.novelpark.DatabaseInitializer;
 import com.novelpark.application.image.S3Uploader;
+import com.novelpark.application.mail.MailService;
 import com.novelpark.domain.image.ImageFile;
 import com.novelpark.presentation.dto.request.auth.SignupRequest;
 import io.restassured.RestAssured;
@@ -37,6 +40,8 @@ public class AuthAcceptanceTest {
 
   @MockBean
   private S3Uploader s3Uploader;
+  @MockBean
+  private MailService mailService;
 
   @AfterEach
   void tearDown() {
@@ -105,6 +110,66 @@ public class AuthAcceptanceTest {
       return request
           .when()
           .post("/api/signup")
+          .then().log().all()
+          .extract();
+    }
+  }
+
+  @DisplayName("아이디를 찾을 때")
+  @Nested
+  class FindLoginId {
+
+    @DisplayName("메일과 이름이 주어지면 아이디가 메일로 발송된다.")
+    @Test
+    void givenNameAndEmail_whenFindLoginId_thenSuccess() throws Exception {
+      // given
+      given(s3Uploader.uploadImageFile(any(ImageFile.class))).willReturn("image resource url");
+      willDoNothing().given(mailService).sendFindLoginFormEmail(anyString(), anyString());
+
+      // 회원가입
+      RestAssured
+          .given()
+          .contentType(MediaType.MULTIPART_FORM_DATA_VALUE)
+          .multiPart("request", objectMapper.writeValueAsString(
+                  new SignupRequest("loginid", "asdf", "jyp", "23Yong@novelpark.com")),
+              MediaType.APPLICATION_JSON_VALUE)
+          .multiPart("image", createStubFile(), MediaType.IMAGE_PNG_VALUE)
+          .when().post("/api/signup")
+          .then();
+
+      var request = requestWithNameAndEmail();
+
+      // when
+      var response = findLoginId(request);
+
+      // then
+      assertThat(response.statusCode()).isEqualTo(200);
+    }
+
+    @DisplayName("존재하지 않는 메일이 주어지면 아이디를 찾는데 실패한다.")
+    @Test
+    void givenNameAndNotExists_whenFindLoginId_thenFail() {
+      // given
+      var request = requestWithNameAndEmail();
+
+      // when
+      var response = findLoginId(request);
+
+      // then
+      assertThat(response.statusCode()).isEqualTo(404);
+    }
+
+    private RequestSpecification requestWithNameAndEmail() {
+      return RestAssured
+          .given().log().all()
+          .queryParam("name", "ParkJeongYong")
+          .queryParam("email", "23Yong@novelpark.com");
+    }
+
+    private ExtractableResponse<Response> findLoginId(RequestSpecification request) {
+      return request
+          .when()
+          .get("/api/id")
           .then().log().all()
           .extract();
     }


### PR DESCRIPTION
## Issue
- #5 

## 변경사항
- `name`과 `email`로 아이디 찾기
  - 이를 위해 JPQL로 쿼리 작성
- 아이디를 찾은 경우 해당 메일로 아이디 전송
  - 비동기로 동작
  - 멀티 스레드 환경을 위한 `AsyncConfig` 설정
  - 스레드풀의 스레드 개수는 2개로 설정했습니다. 
    - 적정 스레드의 개수는 (CPU 코어 수 * (1 + 대기시간/서비스시간))
    - 아이디 찾기가 우리 서비스에서 많은 비중을 차지하지 않아 리소스를 많이 필요로 하지 않을 것이라 예상
    - 위의 이유로 대기시간이 거의 없다고 가정해 1 * (1 + 1)로 계산해 2로 설정

![image](https://github.com/Y-TF/novelpark/assets/66981851/1b830c42-2521-4f48-b6c6-2b43deb43fee)
