### PR TITLE
소셜 로그인

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,8 @@ dependencies {
     // test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'io.rest-assured:rest-assured:4.5.1'
+    testImplementation 'com.squareup.okhttp3:okhttp:4.0.1'
+    testImplementation 'com.squareup.okhttp3:mockwebserver:4.0.1'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/novelpark/application/auth/AuthService.java
+++ b/src/main/java/com/novelpark/application/auth/AuthService.java
@@ -4,6 +4,7 @@ import com.novelpark.application.image.ImageUploadService;
 import com.novelpark.application.mail.MailService;
 import com.novelpark.domain.member.Member;
 import com.novelpark.domain.member.MemberRepository;
+import com.novelpark.domain.member.oauth.OAuthProvider;
 import com.novelpark.exception.BadRequestException;
 import com.novelpark.exception.ErrorCode;
 import com.novelpark.exception.NotFoundException;
@@ -42,6 +43,8 @@ public class AuthService {
     if (memberRepository.existsByLoginId(request.getLoginId())) {
       throw new BadRequestException(ErrorCode.DUPLICATED_LOGIN_ID);
     }
+    memberRepository.findByEmail(request.getEmail())
+        .ifPresent(member -> OAuthProvider.validateOAuthProvider(null, member));
 
     String profileUrl = imageUploadService.uploadImage(image);
 

--- a/src/main/java/com/novelpark/application/auth/OAuthService.java
+++ b/src/main/java/com/novelpark/application/auth/OAuthService.java
@@ -1,0 +1,51 @@
+package com.novelpark.application.auth;
+
+import com.novelpark.application.auth.oauth.OAuthClient;
+import com.novelpark.config.properties.OauthProperties;
+import com.novelpark.domain.member.Member;
+import com.novelpark.domain.member.MemberRepository;
+import com.novelpark.domain.member.oauth.OAuthProvider;
+import com.novelpark.domain.member.oauth.OAuthUser;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Service
+public class OAuthService {
+
+  private final OauthProperties oauthProperties;
+  private final MemberRepository memberRepository;
+
+  public String createRedirectUrl(OAuthProvider oAuthProvider, final String stateToken) {
+    return oAuthProvider.getLoginPageUrl(oauthProperties, stateToken);
+  }
+
+  @Transactional
+  public long oauthLogin(OAuthProvider provider, final String code, final String stateToken) {
+    OAuthClient oAuthClient = provider.getOAuthClient();
+    OAuthUser oAuthUser = oAuthClient.getOAuthUser(code, stateToken);
+
+    String email = oAuthUser.getEmail();
+
+    Member member = memberRepository.findByEmail(email)
+        .orElseGet(() -> Member.builder()
+            .loginId("")
+            .password("")
+            .email(email)
+            .name(oAuthUser.getName())
+            .profileUrl(oAuthUser.getProfileUrl())
+            .oAuthProvider(provider)
+            .build()
+        );
+
+    OAuthProvider.validateOAuthProvider(provider, member);
+
+    // 기존 회원인 경우 로그인 성공
+    if (member.getSeq() != null) {
+      return member.getSeq();
+    }
+    // 기존 회원이 아니라면 강제 회원가입
+    return memberRepository.save(member).getSeq();
+  }
+}

--- a/src/main/java/com/novelpark/application/auth/oauth/KakaoClient.java
+++ b/src/main/java/com/novelpark/application/auth/oauth/KakaoClient.java
@@ -2,7 +2,7 @@ package com.novelpark.application.auth.oauth;
 
 import com.novelpark.config.properties.OauthProperties;
 import com.novelpark.config.properties.OauthProperties.Kakao;
-import com.novelpark.domain.member.oauth.KakaoUser;
+import com.novelpark.domain.member.oauth.KakaoOAuthUser;
 import com.novelpark.domain.member.oauth.OAuthUser;
 import com.novelpark.exception.ErrorCode;
 import com.novelpark.exception.InternalServerException;
@@ -74,7 +74,7 @@ public class KakaoClient implements OAuthClient {
     }
   }
 
-  private KakaoUser requestUserResource(final String token) {
+  private KakaoOAuthUser requestUserResource(final String token) {
     String url = UriComponentsBuilder.fromHttpUrl(resourceServerUrl + "/me")
         .queryParam("property_keys",
             "[\"kakao_account.profile\", \"kakao_account.email\", \"kakao_account.name\"]")
@@ -88,6 +88,6 @@ public class KakaoClient implements OAuthClient {
     HttpEntity<Void> request = new HttpEntity<>(null, httpHeaders);
 
     Map<String, Object> response = restTemplate.postForObject(url, request, Map.class);
-    return new KakaoUser(response);
+    return new KakaoOAuthUser(response);
   }
 }

--- a/src/main/java/com/novelpark/application/auth/oauth/KakaoClient.java
+++ b/src/main/java/com/novelpark/application/auth/oauth/KakaoClient.java
@@ -1,0 +1,93 @@
+package com.novelpark.application.auth.oauth;
+
+import com.novelpark.config.properties.OauthProperties;
+import com.novelpark.config.properties.OauthProperties.Kakao;
+import com.novelpark.domain.member.oauth.KakaoUser;
+import com.novelpark.domain.member.oauth.OAuthUser;
+import com.novelpark.exception.ErrorCode;
+import com.novelpark.exception.InternalServerException;
+import java.util.Map;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+@Component
+public class KakaoClient implements OAuthClient {
+
+  private final RestTemplate restTemplate;
+  private final String clientId;
+  private final String clientSecret;
+  private final String authorizationServerUrl;
+  private final String resourceServerUrl;
+  private final String redirectUrl;
+
+  public KakaoClient(OauthProperties oauthProperties, RestTemplate restTemplate) {
+    Kakao kakaoProperties = oauthProperties.getKakao();
+    this.restTemplate = restTemplate;
+    this.clientId = kakaoProperties.getClientId();
+    this.clientSecret = kakaoProperties.getClientSecret();
+    this.authorizationServerUrl = kakaoProperties.getOAuthApiUrl();
+    this.resourceServerUrl = kakaoProperties.getOAuthResourceUrl();
+    this.redirectUrl = kakaoProperties.getRedirectUrl();
+  }
+
+  @Override
+  public OAuthUser getOAuthUser(final String code, final String stateToken) {
+    String accessToken = requestAccessToken(code);
+    return requestUserResource(accessToken);
+  }
+
+  private String requestAccessToken(final String code) {
+    String url = UriComponentsBuilder.fromHttpUrl(authorizationServerUrl + "/token")
+        .build()
+        .toString();
+    HttpHeaders httpHeaders = new HttpHeaders();
+    httpHeaders.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+    var request = new HttpEntity<>(createTokenRequestBody(code), httpHeaders);
+
+    Map<String, Object> response = restTemplate.postForObject(url, request, Map.class);
+    validateToken(response);
+    return response.get("access_token").toString();
+  }
+
+  private MultiValueMap<String, String> createTokenRequestBody(final String code) {
+    MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+    params.add("grant_type", "authorization_code");
+    params.add("client_id", clientId);
+    params.add("redirect_uri", redirectUrl);
+    params.add("code", code);
+    params.add("client_secret", clientSecret);
+    return params;
+  }
+
+  private void validateToken(Map<String, Object> tokenResponse) {
+    if (!tokenResponse.containsKey("access_token")) {
+      throw new InternalServerException(
+          ErrorCode.OAUTH_FAIL_REQUEST_TOKEN,
+          tokenResponse.get("error_description").toString()
+      );
+    }
+  }
+
+  private KakaoUser requestUserResource(final String token) {
+    String url = UriComponentsBuilder.fromHttpUrl(resourceServerUrl + "/me")
+        .queryParam("property_keys",
+            "[\"kakao_account.profile\", \"kakao_account.email\", \"kakao_account.name\"]")
+        .build()
+        .toString();
+
+    HttpHeaders httpHeaders = new HttpHeaders();
+    httpHeaders.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+    httpHeaders.setBearerAuth(token);
+
+    HttpEntity<Void> request = new HttpEntity<>(null, httpHeaders);
+
+    Map<String, Object> response = restTemplate.postForObject(url, request, Map.class);
+    return new KakaoUser(response);
+  }
+}

--- a/src/main/java/com/novelpark/application/auth/oauth/NaverClient.java
+++ b/src/main/java/com/novelpark/application/auth/oauth/NaverClient.java
@@ -1,0 +1,73 @@
+package com.novelpark.application.auth.oauth;
+
+import com.novelpark.config.properties.OauthProperties;
+import com.novelpark.config.properties.OauthProperties.Naver;
+import com.novelpark.domain.member.oauth.NaverUser;
+import com.novelpark.domain.member.oauth.OAuthUser;
+import com.novelpark.exception.ErrorCode;
+import com.novelpark.exception.InternalServerException;
+import java.util.Map;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+@Component
+public class NaverClient implements OAuthClient {
+
+  private final RestTemplate restTemplate;
+  private final String clientId;
+  private final String clientSecret;
+  private final String authorizationServerUrl;
+  private final String resourceServerUrl;
+
+  public NaverClient(OauthProperties oauthProperties, RestTemplate restTemplate) {
+    Naver naverProperties = oauthProperties.getNaver();
+    this.restTemplate = restTemplate;
+    this.clientId = naverProperties.getClientId();
+    this.clientSecret = naverProperties.getClientSecret();
+    this.authorizationServerUrl = naverProperties.getOAuthApiUrl();
+    this.resourceServerUrl = naverProperties.getOAuthResourceUrl();
+  }
+
+  @Override
+  public OAuthUser getOAuthUser(final String code, final String stateToken) {
+    String accessToken = requestAccessToken(code, stateToken);
+    return requestUserResource(accessToken);
+  }
+
+  private String requestAccessToken(final String code, final String stateToken) {
+    String url = UriComponentsBuilder.fromHttpUrl(authorizationServerUrl + "/token")
+        .queryParam("grant_type", "authorization_code")
+        .queryParam("client_id", clientId)
+        .queryParam("client_secret", clientSecret)
+        .queryParam("code", code)
+        .queryParam("state", stateToken)
+        .build()
+        .toString();
+
+    Map<String, Object> tokenResponse = restTemplate.postForObject(url, null, Map.class);
+    validateToken(tokenResponse);
+    return tokenResponse.get("access_token").toString();
+  }
+
+  private void validateToken(Map<String, Object> tokenResponse) {
+    if (!tokenResponse.containsKey("access_token")) {
+      throw new InternalServerException(
+          ErrorCode.OAUTH_FAIL_REQUEST_TOKEN,
+          tokenResponse.get("error_description").toString()
+      );
+    }
+  }
+
+  private OAuthUser requestUserResource(String accessToken) {
+    HttpHeaders httpHeaders = new HttpHeaders();
+    httpHeaders.add(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken);
+    HttpEntity<Void> request = new HttpEntity<>(null, httpHeaders);
+
+    Map<String, Object> response = restTemplate.postForObject(resourceServerUrl + "/me", request,
+        Map.class);
+    return new NaverUser(response);
+  }
+}

--- a/src/main/java/com/novelpark/application/auth/oauth/NaverClient.java
+++ b/src/main/java/com/novelpark/application/auth/oauth/NaverClient.java
@@ -2,7 +2,7 @@ package com.novelpark.application.auth.oauth;
 
 import com.novelpark.config.properties.OauthProperties;
 import com.novelpark.config.properties.OauthProperties.Naver;
-import com.novelpark.domain.member.oauth.NaverUser;
+import com.novelpark.domain.member.oauth.NaverOAuthUser;
 import com.novelpark.domain.member.oauth.OAuthUser;
 import com.novelpark.exception.ErrorCode;
 import com.novelpark.exception.InternalServerException;
@@ -68,6 +68,6 @@ public class NaverClient implements OAuthClient {
 
     Map<String, Object> response = restTemplate.postForObject(resourceServerUrl + "/me", request,
         Map.class);
-    return new NaverUser(response);
+    return new NaverOAuthUser(response);
   }
 }

--- a/src/main/java/com/novelpark/application/auth/oauth/OAuthClient.java
+++ b/src/main/java/com/novelpark/application/auth/oauth/OAuthClient.java
@@ -1,0 +1,8 @@
+package com.novelpark.application.auth.oauth;
+
+import com.novelpark.domain.member.oauth.OAuthUser;
+
+public interface OAuthClient {
+
+  OAuthUser getOAuthUser(String code, String stateToken);
+}

--- a/src/main/java/com/novelpark/application/auth/oauth/StateGenerator.java
+++ b/src/main/java/com/novelpark/application/auth/oauth/StateGenerator.java
@@ -1,0 +1,20 @@
+package com.novelpark.application.auth.oauth;
+
+import java.math.BigInteger;
+import java.security.SecureRandom;
+
+public final class StateGenerator {
+
+  private static final SecureRandom random = new SecureRandom();
+
+  private StateGenerator() {
+  }
+
+  public static String generateState() {
+    return new BigInteger(130, random).toString(32);
+  }
+
+  public static boolean validateStateToken(String stateFromQueryParam, String stateFromSession) {
+    return stateFromQueryParam.equals(stateFromSession);
+  }
+}

--- a/src/main/java/com/novelpark/application/auth/oauth/StateGenerator.java
+++ b/src/main/java/com/novelpark/application/auth/oauth/StateGenerator.java
@@ -3,6 +3,9 @@ package com.novelpark.application.auth.oauth;
 import java.math.BigInteger;
 import java.security.SecureRandom;
 
+/**
+ * OAuth 로그인시 상태토큰을 생성하는 클래스
+ */
 public final class StateGenerator {
 
   private static final SecureRandom random = new SecureRandom();

--- a/src/main/java/com/novelpark/config/InfraConfig.java
+++ b/src/main/java/com/novelpark/config/InfraConfig.java
@@ -1,0 +1,10 @@
+package com.novelpark.config;
+
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+import org.springframework.context.annotation.Configuration;
+
+@ConfigurationPropertiesScan({"com.novelpark.config.properties"})
+@Configuration
+public class InfraConfig {
+
+}

--- a/src/main/java/com/novelpark/config/RestTemplateConfig.java
+++ b/src/main/java/com/novelpark/config/RestTemplateConfig.java
@@ -1,0 +1,34 @@
+package com.novelpark.config;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.ClientHttpResponse;
+import org.springframework.web.client.DefaultResponseErrorHandler;
+import org.springframework.web.client.RestTemplate;
+
+@Slf4j
+@Configuration
+public class RestTemplateConfig {
+
+  @Bean
+  public RestTemplate restTemplate(RestTemplateBuilder builder) {
+    return builder
+        .setConnectTimeout(Duration.ofSeconds(10)) // set connection timeout
+        .setReadTimeout(Duration.ofSeconds(10))    // set read timeout
+        .errorHandler(new CustomErrorHandler())   // add custom error handler
+        .build();
+  }
+
+  private static class CustomErrorHandler extends DefaultResponseErrorHandler {
+
+    @Override
+    public void handleError(ClientHttpResponse response) throws IOException {
+      log.error(new String(response.getBody().readAllBytes(), StandardCharsets.UTF_8));
+    }
+  }
+}

--- a/src/main/java/com/novelpark/config/WebConfig.java
+++ b/src/main/java/com/novelpark/config/WebConfig.java
@@ -1,0 +1,19 @@
+package com.novelpark.config;
+
+import com.novelpark.presentation.converter.OAuthProviderRequestConverter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.format.FormatterRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@RequiredArgsConstructor
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+  private final OAuthProviderRequestConverter oauthProviderConverter;
+
+  @Override
+  public void addFormatters(FormatterRegistry registry) {
+    registry.addConverter(oauthProviderConverter);
+  }
+}

--- a/src/main/java/com/novelpark/config/properties/OauthProperties.java
+++ b/src/main/java/com/novelpark/config/properties/OauthProperties.java
@@ -1,0 +1,42 @@
+package com.novelpark.config.properties;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.ConstructorBinding;
+
+@Getter
+@ConfigurationProperties("oauth")
+public class OauthProperties {
+
+  private final Naver naver;
+  private final Kakao kakao;
+
+  @ConstructorBinding
+  public OauthProperties(Naver naver, Kakao kakao) {
+    this.naver = naver;
+    this.kakao = kakao;
+  }
+
+  @Getter
+  @RequiredArgsConstructor
+  public static class Naver {
+
+    private final String clientId;
+    private final String clientSecret;
+    private final String oAuthApiUrl;
+    private final String oAuthResourceUrl;
+    private final String redirectUrl;
+  }
+
+  @Getter
+  @RequiredArgsConstructor
+  public static class Kakao {
+
+    private final String clientId;
+    private final String clientSecret;
+    private final String oAuthApiUrl;
+    private final String oAuthResourceUrl;
+    private final String redirectUrl;
+  }
+}

--- a/src/main/java/com/novelpark/domain/member/Member.java
+++ b/src/main/java/com/novelpark/domain/member/Member.java
@@ -1,15 +1,15 @@
 package com.novelpark.domain.member;
 
+import com.novelpark.domain.AuditingFields;
+import com.novelpark.domain.member.oauth.OAuthProvider;
 import java.util.Objects;
-
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
-
-import com.novelpark.domain.AuditingFields;
-
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -20,46 +20,54 @@ import lombok.NoArgsConstructor;
 @Entity
 public class Member extends AuditingFields {
 
-	@Id
-	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	private Long seq;
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long seq;
 
-	@Column(length = 45, nullable = false)
-	private String loginId;
+  @Column(length = 45, nullable = false)
+  private String loginId;
 
-	@Column(length = 512, nullable = false)
-	private String password;
+  @Column(length = 512, nullable = false)
+  private String password;
 
-	@Column(length = 30, nullable = false)
-	private String name;
+  @Column(length = 30, nullable = false)
+  private String name;
 
-	@Column(length = 45, nullable = false)
-	private String email;
+  @Column(length = 45, nullable = false)
+  private String email;
 
-	@Column(length = 512, nullable = false)
-	private String profileUrl;
+  @Column(length = 512, nullable = false)
+  private String profileUrl;
 
-	@Builder
-	public Member(String loginId, String password, String name, String email, String profileUrl) {
-		this.loginId = loginId;
-		this.password = password;
-		this.name = name;
-		this.email = email;
-		this.profileUrl = profileUrl;
-	}
+  @Column(length = 45)
+  @Enumerated(EnumType.STRING)
+  private OAuthProvider OAuthProvider;
 
-	@Override
-	public boolean equals(Object o) {
-		if (this == o)
-			return true;
-		if (o == null || getClass() != o.getClass())
-			return false;
-		Member member = (Member)o;
-		return Objects.equals(seq, member.seq);
-	}
+  @Builder
+  public Member(String loginId, String password, String name, String email, String profileUrl,
+      OAuthProvider oAuthProvider) {
+    this.loginId = loginId;
+    this.password = password;
+    this.name = name;
+    this.email = email;
+    this.profileUrl = profileUrl;
+    this.OAuthProvider = oAuthProvider;
+  }
 
-	@Override
-	public int hashCode() {
-		return Objects.hash(seq);
-	}
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof Member)) {
+      return false;
+    }
+    Member member = (Member) o;
+    return Objects.equals(seq, member.seq);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(seq);
+  }
 }

--- a/src/main/java/com/novelpark/domain/member/MemberRepository.java
+++ b/src/main/java/com/novelpark/domain/member/MemberRepository.java
@@ -16,4 +16,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
       @Param("email") String email,
       @Param("name") String name
   );
+
+  Optional<Member> findByEmail(String email);
 }

--- a/src/main/java/com/novelpark/domain/member/oauth/KakaoOAuthUser.java
+++ b/src/main/java/com/novelpark/domain/member/oauth/KakaoOAuthUser.java
@@ -3,11 +3,11 @@ package com.novelpark.domain.member.oauth;
 import java.util.Collections;
 import java.util.Map;
 
-public class KakaoUser implements OAuthUser {
+public class KakaoOAuthUser implements OAuthUser {
 
   private final Map<String, Object> userInfo;
 
-  public KakaoUser(Map<String, Object> userInfo) {
+  public KakaoOAuthUser(Map<String, Object> userInfo) {
     this.userInfo = Collections.unmodifiableMap(userInfo);
   }
 

--- a/src/main/java/com/novelpark/domain/member/oauth/KakaoUser.java
+++ b/src/main/java/com/novelpark/domain/member/oauth/KakaoUser.java
@@ -1,0 +1,36 @@
+package com.novelpark.domain.member.oauth;
+
+import java.util.Collections;
+import java.util.Map;
+
+public class KakaoUser implements OAuthUser {
+
+  private final Map<String, Object> userInfo;
+
+  public KakaoUser(Map<String, Object> userInfo) {
+    this.userInfo = Collections.unmodifiableMap(userInfo);
+  }
+
+  @Override
+  public String getEmail() {
+    return getKakaoAccount().get("email").toString();
+  }
+
+  @Override
+  public String getName() {
+    return getProfile().get("nickname");
+  }
+
+  @Override
+  public String getProfileUrl() {
+    return getProfile().get("profile_image_url");
+  }
+
+  private Map<String, String> getProfile() {
+    return (Map<String, String>) getKakaoAccount().get("profile");
+  }
+
+  private Map<String, Object> getKakaoAccount() {
+    return (Map<String, Object>) userInfo.get("kakao_account");
+  }
+}

--- a/src/main/java/com/novelpark/domain/member/oauth/NaverOAuthUser.java
+++ b/src/main/java/com/novelpark/domain/member/oauth/NaverOAuthUser.java
@@ -3,11 +3,11 @@ package com.novelpark.domain.member.oauth;
 import java.util.Collections;
 import java.util.Map;
 
-public class NaverUser implements OAuthUser {
+public class NaverOAuthUser implements OAuthUser {
 
   private final Map<String, Object> userInfo;
 
-  public NaverUser(Map<String, Object> userInfo) {
+  public NaverOAuthUser(Map<String, Object> userInfo) {
     this.userInfo = Collections.unmodifiableMap(userInfo);
   }
 

--- a/src/main/java/com/novelpark/domain/member/oauth/NaverUser.java
+++ b/src/main/java/com/novelpark/domain/member/oauth/NaverUser.java
@@ -1,0 +1,32 @@
+package com.novelpark.domain.member.oauth;
+
+import java.util.Collections;
+import java.util.Map;
+
+public class NaverUser implements OAuthUser {
+
+  private final Map<String, Object> userInfo;
+
+  public NaverUser(Map<String, Object> userInfo) {
+    this.userInfo = Collections.unmodifiableMap(userInfo);
+  }
+
+  @Override
+  public String getEmail() {
+    return getResponse().get("email");
+  }
+
+  @Override
+  public String getName() {
+    return getResponse().get("name");
+  }
+
+  @Override
+  public String getProfileUrl() {
+    return getResponse().get("profile_image");
+  }
+
+  private Map<String, String> getResponse() {
+    return (Map<String, String>) userInfo.get("response");
+  }
+}

--- a/src/main/java/com/novelpark/domain/member/oauth/OAuthProvider.java
+++ b/src/main/java/com/novelpark/domain/member/oauth/OAuthProvider.java
@@ -55,7 +55,7 @@ public enum OAuthProvider {
   public static void validateOAuthProvider(OAuthProvider provider, Member member) {
     String exceptionMessage;
     if (member.getOAuthProvider() == null) {
-      exceptionMessage = String.format("해당 이메일은 %s로 회원가입된 이력이 있습니다.", "아이디/비밀번호");
+      exceptionMessage = "해당 이메일은 아이디/비밀번호로 회원가입된 이력이 있습니다.";
     } else {
       exceptionMessage =
           String.format("해당 이메일은 %s로 회원가입된 이력이 있습니다.", member.getOAuthProvider().name());

--- a/src/main/java/com/novelpark/domain/member/oauth/OAuthProvider.java
+++ b/src/main/java/com/novelpark/domain/member/oauth/OAuthProvider.java
@@ -1,0 +1,94 @@
+package com.novelpark.domain.member.oauth;
+
+import com.novelpark.application.auth.oauth.KakaoClient;
+import com.novelpark.application.auth.oauth.NaverClient;
+import com.novelpark.application.auth.oauth.OAuthClient;
+import com.novelpark.config.properties.OauthProperties;
+import com.novelpark.domain.member.Member;
+import com.novelpark.exception.BadRequestException;
+import com.novelpark.exception.ErrorCode;
+import com.novelpark.exception.NotFoundException;
+import java.util.Arrays;
+import javax.annotation.PostConstruct;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Getter
+@RequiredArgsConstructor
+public enum OAuthProvider {
+
+  KAKAO("kakao") {
+    @Override
+    public String getLoginPageUrl(OauthProperties oauthProperties, String stateToken) {
+      return oauthProperties.getKakao().getOAuthApiUrl() +
+          "/authorize?" +
+          "client_id=" + oauthProperties.getKakao().getClientId() +
+          "&redirect_uri=" + oauthProperties.getKakao().getRedirectUrl() +
+          "&response_type=code" +
+          "&state=" + stateToken;
+    }
+  },
+  NAVER("naver") {
+    @Override
+    public String getLoginPageUrl(OauthProperties oauthProperties, String stateToken) {
+      return oauthProperties.getNaver().getOAuthApiUrl() +
+          "/authorize?" +
+          "client_id=" + oauthProperties.getNaver().getClientId() +
+          "&response_type=code" +
+          "&redirect_uri=" + oauthProperties.getNaver().getRedirectUrl() +
+          "&state=" + stateToken;
+    }
+  };
+
+  private final String name;
+
+  private OAuthClient oAuthClient;
+
+  public static OAuthProvider of(final String name) {
+    return Arrays.stream(OAuthProvider.values())
+        .filter(provider -> provider.name.equals(name))
+        .findFirst()
+        .orElseThrow(() -> new NotFoundException(ErrorCode.OAUTH_PROVIDER_NOT_FOUND));
+  }
+
+  public static void validateOAuthProvider(OAuthProvider provider, Member member) {
+    String exceptionMessage;
+    if (member.getOAuthProvider() == null) {
+      exceptionMessage = String.format("해당 이메일은 %s로 회원가입된 이력이 있습니다.", "아이디/비밀번호");
+    } else {
+      exceptionMessage =
+          String.format("해당 이메일은 %s로 회원가입된 이력이 있습니다.", member.getOAuthProvider().name());
+    }
+
+    if (provider != member.getOAuthProvider()) {
+      throw new BadRequestException(ErrorCode.NOT_MATCH_PROVIDER, exceptionMessage);
+    }
+  }
+
+  public abstract String getLoginPageUrl(OauthProperties oauthProperties, String stateToken);
+
+  private void injectOAuthClient(OAuthClient oAuthClient) {
+    this.oAuthClient = oAuthClient;
+  }
+
+  @RequiredArgsConstructor
+  @Component
+  static class OAuthClientInjector {
+
+    private final NaverClient naverClient;
+    private final KakaoClient kakaoClient;
+
+    @PostConstruct
+    public void injectOAuthClient() {
+      Arrays.stream(OAuthProvider.values()).forEach(oAuthProvider -> {
+        if (oAuthProvider == NAVER) {
+          oAuthProvider.injectOAuthClient(naverClient);
+        }
+        if (oAuthProvider == KAKAO) {
+          oAuthProvider.injectOAuthClient(kakaoClient);
+        }
+      });
+    }
+  }
+}

--- a/src/main/java/com/novelpark/domain/member/oauth/OAuthUser.java
+++ b/src/main/java/com/novelpark/domain/member/oauth/OAuthUser.java
@@ -1,0 +1,10 @@
+package com.novelpark.domain.member.oauth;
+
+public interface OAuthUser {
+
+  String getEmail();
+
+  String getName();
+
+  String getProfileUrl();
+}

--- a/src/main/java/com/novelpark/exception/ErrorCode.java
+++ b/src/main/java/com/novelpark/exception/ErrorCode.java
@@ -15,7 +15,7 @@ public enum ErrorCode {
   OAUTH_PROVIDER_NOT_FOUND("해당 OAuth 제공자가 존재하지 않습니다."),
   INVALID_STATE_TOKEN("상태 토큰이 일치하지 않습니다."),
   OAUTH_FAIL_REQUEST_TOKEN("토큰 발급에 실패했습니다."),
-  NOT_MATCH_PROVIDER(""),
+  NOT_MATCH_PROVIDER("해당 서비스의 로그인 기능은 제공하지 않습니다."),
 
   // IMAGE
   INVALID_IMAGE("이미지 업로드에 실패했습니다."),

--- a/src/main/java/com/novelpark/exception/ErrorCode.java
+++ b/src/main/java/com/novelpark/exception/ErrorCode.java
@@ -11,6 +11,12 @@ public enum ErrorCode {
   USER_NOT_FOUND("해당 유저를 찾을 수 없습니다."),
   INVALID_PASSWORD("비밀번호가 일치하지 않습니다."),
 
+  // OAUTH
+  OAUTH_PROVIDER_NOT_FOUND("해당 OAuth 제공자가 존재하지 않습니다."),
+  INVALID_STATE_TOKEN("상태 토큰이 일치하지 않습니다."),
+  OAUTH_FAIL_REQUEST_TOKEN("토큰 발급에 실패했습니다."),
+  NOT_MATCH_PROVIDER(""),
+
   // IMAGE
   INVALID_IMAGE("이미지 업로드에 실패했습니다."),
   INVALID_FILE_EXTENSION("이미지 파일의 확장자는 png, jpg, jpeg, gif만 가능합니다."),

--- a/src/main/java/com/novelpark/presentation/AuthController.java
+++ b/src/main/java/com/novelpark/presentation/AuthController.java
@@ -1,13 +1,11 @@
 package com.novelpark.presentation;
 
 import com.novelpark.application.auth.AuthService;
-import com.novelpark.application.constant.AuthConstant;
 import com.novelpark.presentation.dto.request.auth.LoginRequest;
 import com.novelpark.presentation.dto.request.auth.SignupRequest;
-import javax.servlet.http.Cookie;
+import com.novelpark.presentation.support.SessionUtil;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import javax.servlet.http.HttpSession;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -37,15 +35,7 @@ public class AuthController {
   ) {
     final long memberSeq = authService.login(loginReq);
 
-    // 세션 생성
-    HttpSession session = servletReq.getSession(true);
-    session.setAttribute(AuthConstant.SESSION_ATTR_NAME, memberSeq);
-    session.setMaxInactiveInterval(AuthConstant.SESSION_TIMEOUT_IN_SECONDS);
-
-    // 쿠키 생성 및 응답 헤더에 추가
-    Cookie sessionCookie = new Cookie(AuthConstant.JSESSIONID, session.getId());
-    sessionCookie.setHttpOnly(true);
-    servletRes.addCookie(sessionCookie);
+    SessionUtil.setSessionAttribute(servletReq, servletRes, memberSeq);
 
     return ResponseEntity.ok().build();
   }

--- a/src/main/java/com/novelpark/presentation/OAuthController.java
+++ b/src/main/java/com/novelpark/presentation/OAuthController.java
@@ -1,0 +1,64 @@
+package com.novelpark.presentation;
+
+import com.novelpark.application.auth.OAuthService;
+import com.novelpark.application.auth.oauth.StateGenerator;
+import com.novelpark.domain.member.oauth.OAuthProvider;
+import com.novelpark.exception.BadRequestException;
+import com.novelpark.exception.ErrorCode;
+import com.novelpark.presentation.support.SessionUtil;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.SessionAttribute;
+
+@RequiredArgsConstructor
+@RequestMapping("/api/login/OAuth/{provider}")
+@RestController
+public class OAuthController {
+
+  private final OAuthService oAuthService;
+
+  @GetMapping("/page")
+  public ResponseEntity<String> redirectToLoginPage(
+      @PathVariable OAuthProvider provider,
+      HttpServletRequest request
+  ) {
+    // 상태토큰 설정
+    HttpSession session = request.getSession(true);
+    String stateToken = StateGenerator.generateState();
+    session.setAttribute("state", stateToken);
+
+    return ResponseEntity.status(HttpStatus.FOUND)
+        .header(HttpHeaders.LOCATION, oAuthService.createRedirectUrl(provider, stateToken))
+        .build();
+  }
+
+  @GetMapping
+  public ResponseEntity<Void> oAuthLogin(
+      @PathVariable OAuthProvider provider,
+      @RequestParam("state") String stateFromQueryParam,
+      @RequestParam String code,
+      @SessionAttribute(value = "state", required = false) String stateFromSession,
+      HttpServletRequest request,
+      HttpServletResponse response
+  ) {
+    // 상태 토큰 검증
+    if (!StateGenerator.validateStateToken(stateFromQueryParam, stateFromSession)) {
+      throw new BadRequestException(ErrorCode.INVALID_STATE_TOKEN);
+    }
+
+    long memberId = oAuthService.oauthLogin(provider, code, stateFromQueryParam);
+    SessionUtil.setSessionAttribute(request, response, memberId);
+
+    return ResponseEntity.ok().build();
+  }
+}

--- a/src/main/java/com/novelpark/presentation/converter/OAuthProviderRequestConverter.java
+++ b/src/main/java/com/novelpark/presentation/converter/OAuthProviderRequestConverter.java
@@ -1,0 +1,14 @@
+package com.novelpark.presentation.converter;
+
+import com.novelpark.domain.member.oauth.OAuthProvider;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.stereotype.Component;
+
+@Component
+public class OAuthProviderRequestConverter implements Converter<String, OAuthProvider> {
+
+  @Override
+  public OAuthProvider convert(String oauthProvider) {
+    return OAuthProvider.of(oauthProvider);
+  }
+}

--- a/src/main/java/com/novelpark/presentation/support/SessionUtil.java
+++ b/src/main/java/com/novelpark/presentation/support/SessionUtil.java
@@ -1,0 +1,30 @@
+package com.novelpark.presentation.support;
+
+import com.novelpark.application.constant.AuthConstant;
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
+
+public final class SessionUtil {
+
+  private SessionUtil() {
+    
+  }
+
+  public static void setSessionAttribute(
+      HttpServletRequest request,
+      HttpServletResponse response,
+      long memberSeq
+  ) {
+    // 세션 생성
+    HttpSession session = request.getSession(true);
+    session.setAttribute(AuthConstant.SESSION_ATTR_NAME, memberSeq);
+    session.setMaxInactiveInterval(AuthConstant.SESSION_TIMEOUT_IN_SECONDS);
+
+    // 쿠키 생성 및 응답 헤더에 추가
+    Cookie sessionCookie = new Cookie(AuthConstant.JSESSIONID, session.getId());
+    sessionCookie.setHttpOnly(true);
+    response.addCookie(sessionCookie);
+  }
+}

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -39,3 +39,17 @@ cloud:
 s3:
   default:
     profile-url: https://novel-park-bucket.s3.ap-northeast-2.amazonaws.com/public/profiles/default_profile.png
+
+oauth:
+  naver:
+    client-id: clientId
+    client-secret: clientSecret
+    oauth-api-url: https://nid.naver.com/oauth2.0
+    oauth-resource-url: https://openapi.naver.com/v1/nid
+    redirect-url: redirect-url
+  kakao:
+    client-id: clientId
+    client-secret: clientSecret
+    oauth-api-url: https://kauth.kakao.com/oauth
+    oauth-resource-url: https://kapi.kakao.com/v2/user
+    redirect-url: redirect-url

--- a/src/test/java/com/novelpark/acceptance/AuthAcceptanceTest.java
+++ b/src/test/java/com/novelpark/acceptance/AuthAcceptanceTest.java
@@ -131,7 +131,7 @@ public class AuthAcceptanceTest {
           .given()
           .contentType(MediaType.MULTIPART_FORM_DATA_VALUE)
           .multiPart("request", objectMapper.writeValueAsString(
-                  new SignupRequest("loginid", "asdf", "jyp", "23Yong@novelpark.com")),
+                  new SignupRequest("loginid", "asdf", "ParkJeongYong", "23Yong@novelpark.com")),
               MediaType.APPLICATION_JSON_VALUE)
           .multiPart("image", createStubFile(), MediaType.IMAGE_PNG_VALUE)
           .when().post("/api/signup")

--- a/src/test/java/com/novelpark/application/auth/oauth/NaverClientTest.java
+++ b/src/test/java/com/novelpark/application/auth/oauth/NaverClientTest.java
@@ -1,0 +1,106 @@
+package com.novelpark.application.auth.oauth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.novelpark.config.properties.OauthProperties;
+import com.novelpark.config.properties.OauthProperties.Naver;
+import com.novelpark.domain.member.oauth.OAuthUser;
+import com.novelpark.exception.ErrorCode;
+import com.novelpark.exception.InternalServerException;
+import java.io.IOException;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.apache.http.HttpHeaders;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.web.client.RestTemplate;
+
+class NaverClientTest {
+
+  private static final String TOKEN_RESPONSE = "{\n"
+      + "    \"access_token\": \"AAAAQosjWDJieBiQZc3to9YQp6HDLvrmyKC+6+iZ3gq7qrkqf50ljZC+Lgoqrg\",\n"
+      + "    \"refresh_token\": \"c8ceMEJisO4Se7uGisHoX0f5JEii7JnipglQipkOn5Zp3tyP7dHQoP0zNKHUq2gY\",\n"
+      + "    \"token_type\": \"bearer\",\n"
+      + "    \"expires_in\": \"3600\"\n"
+      + "}";
+  private static final String USER_RESPONSE = "{\n"
+      + "  \"resultcode\": \"00\",\n"
+      + "  \"message\": \"success\",\n"
+      + "  \"response\": {\n"
+      + "    \"email\": \"openapi@naver.com\",\n"
+      + "    \"nickname\": \"OpenAPI\",\n"
+      + "    \"profile_image\": \"https://ssl.pstatic.net/static/pwe/address/nodata_33x33.gif\",\n"
+      + "    \"age\": \"40-49\",\n"
+      + "    \"gender\": \"F\",\n"
+      + "    \"id\": \"32742776\",\n"
+      + "    \"name\": \"오픈 API\",\n"
+      + "    \"birthday\": \"10-01\"\n"
+      + "  }\n"
+      + "}";
+  private static final String ERROR_RESPONSE = "{\n"
+      + "    \"error\": \"invalid_request\",\n"
+      + "    \"error_description\": \"no valid data in session\"\n"
+      + "}";
+
+  @DisplayName("Naver 서버에 요청을 보내 인가코드로부터 유저의 정보를 가져오는데 성공한다.")
+  @Test
+  void givenMockWebServer_whenRequestNaverUserResoruce_thenSuccess() {
+    try (MockWebServer mockOAuthServer = new MockWebServer()) {
+      // given
+      mockOAuthServer.start();
+      setUpMockResponse(mockOAuthServer, TOKEN_RESPONSE);
+      setUpMockResponse(mockOAuthServer, USER_RESPONSE);
+
+      NaverClient naverClient = new NaverClient(new OauthProperties(new Naver(
+          "clientId",
+          "clientSecret",
+          String.format("http://%s:%s", mockOAuthServer.getHostName(), mockOAuthServer.getPort()),
+          String.format("http://%s:%s", mockOAuthServer.getHostName(), mockOAuthServer.getPort()),
+          "redirectUrl"
+      ), null), new RestTemplate());
+
+      // when
+      OAuthUser naverUser = naverClient.getOAuthUser("code", "stateToken");
+      String email = naverUser.getEmail();
+
+      // then
+      assertThat(email).isEqualTo("openapi@naver.com");
+      mockOAuthServer.shutdown();
+    } catch (IOException ignored) {
+    }
+  }
+
+  @DisplayName("Naver 서버에 요청을 보낼 때 access token을 가져오는데 실패한다.")
+  @Test
+  void givenInvalidInfo_whenRequestNaverUserResouce_thenFail() {
+    try (MockWebServer mockOAuthServer = new MockWebServer()) {
+      // given
+      mockOAuthServer.start();
+      setUpMockResponse(mockOAuthServer, ERROR_RESPONSE);
+
+      NaverClient naverClient = new NaverClient(new OauthProperties(new Naver(
+          "clientId",
+          "clientSecret",
+          String.format("http://%s:%s", mockOAuthServer.getHostName(), mockOAuthServer.getPort()),
+          String.format("http://%s:%s", mockOAuthServer.getHostName(), mockOAuthServer.getPort()),
+          "redirectUrl"
+      ), null), new RestTemplate());
+
+      // when & then
+      assertThatThrownBy(() -> naverClient.getOAuthUser("code", "stateToken"))
+          .isInstanceOf(InternalServerException.class)
+          .extracting("errorCode").isEqualTo(ErrorCode.OAUTH_FAIL_REQUEST_TOKEN);
+
+      mockOAuthServer.shutdown();
+    } catch (IOException ignored) {
+    }
+  }
+
+  private void setUpMockResponse(MockWebServer mockOAuthServer, String mockResponse) {
+    mockOAuthServer.enqueue(new MockResponse()
+        .setBody(mockResponse)
+        .addHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE));
+  }
+}

--- a/src/test/java/com/novelpark/domain/member/oauth/OAuthProviderTest.java
+++ b/src/test/java/com/novelpark/domain/member/oauth/OAuthProviderTest.java
@@ -1,0 +1,24 @@
+package com.novelpark.domain.member.oauth;
+
+import com.novelpark.application.auth.oauth.KakaoClient;
+import com.novelpark.application.auth.oauth.NaverClient;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class OAuthProviderTest {
+
+  @DisplayName("OAuthProvider가 JVM에 로드될 때 OAuthClient 빈이 주입된다.")
+  @Test
+  void given_whenOAuthProviderLoadedOnJVM_thenInjectOAuthClientBean() {
+    OAuthProvider naver = OAuthProvider.NAVER;
+    OAuthProvider kakao = OAuthProvider.KAKAO;
+
+    SoftAssertions.assertSoftly(softAssertions -> {
+      softAssertions.assertThat(naver.getOAuthClient()).isInstanceOf(NaverClient.class);
+      softAssertions.assertThat(kakao.getOAuthClient()).isInstanceOf(KakaoClient.class);
+    });
+  }
+}


### PR DESCRIPTION
## Issue
- #12 

## 변경사항
- 카카오/네이버 로그인 구현
- `OAuthProvider` enum 에서 `OAuthClient` 빈을 주입받기 위해 `@PostConstruct` 애노테이션을 사용해 강제 주입
- RestTemplate 을 사용
  - WebClient를 사용하기 위해 webflux dependency를 추가하는 것은 아니라고 생각
  - 어차피 사용자 정보를 받아올 때는 동기방식으로 진행해야하기 때문에

## 고민사항
- 소셜 로그인시 최초 로그인의 경우 강제 회원가입을 시켜줘야 할까?
  - 다른 서비스도 별도의 추가 정보를 입력한 일이 없었던 경험으로 우선 강제 회원가입을 시켜준다.
- 회원가입한 provider와 다른 provider로 같은 이메일로 소셜 로그인하면 어떻게 해야할까?
  - 오류를 발생시키고 이미 가입된 provider를 알려주기
- 회원가입시 일반 회원가입을 했는데 같은 이메일로 소셜 로그인하면 어떻게 해야할까?
  - 오류를 발생시키고 아이디/비밀번호로 로그인하라고 알려주기
