### PR TITLE
소설 등록 기능

### DIFF
--- a/src/main/java/com/novelpark/application/novel/NovelService.java
+++ b/src/main/java/com/novelpark/application/novel/NovelService.java
@@ -1,0 +1,27 @@
+package com.novelpark.application.novel;
+
+import com.novelpark.application.image.ImageUploadService;
+import com.novelpark.domain.novel.Novel;
+import com.novelpark.domain.novel.NovelRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+@RequiredArgsConstructor
+@Service
+public class NovelService {
+
+  private final NovelRepository novelRepository;
+  private final ImageUploadService imageUploadService;
+
+  @Transactional
+  public void register(String title, MultipartFile coverImage) {
+    String coverImageUrl = imageUploadService.uploadImage(coverImage);
+
+    novelRepository.save(Novel.builder()
+        .title(title)
+        .coverImageUrl(coverImageUrl)
+        .build());
+  }
+}

--- a/src/main/java/com/novelpark/config/FilterConfig.java
+++ b/src/main/java/com/novelpark/config/FilterConfig.java
@@ -1,0 +1,34 @@
+package com.novelpark.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.novelpark.presentation.filter.AuthExceptionHandlerFilter;
+import com.novelpark.presentation.filter.SessionFilter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@RequiredArgsConstructor
+@Configuration
+public class FilterConfig {
+
+  private final ObjectMapper objectMapper;
+
+  @Bean
+  public FilterRegistrationBean<SessionFilter> jwtFilter() {
+    FilterRegistrationBean<SessionFilter> jwtFilter = new FilterRegistrationBean<>();
+    jwtFilter.setFilter(new SessionFilter());
+    jwtFilter.addUrlPatterns("/api/*");
+    jwtFilter.setOrder(2);
+    return jwtFilter;
+  }
+
+  @Bean
+  public FilterRegistrationBean<AuthExceptionHandlerFilter> authExceptionHandlerFilter() {
+    FilterRegistrationBean<AuthExceptionHandlerFilter> authExceptionHandlerFilter = new FilterRegistrationBean<>();
+    authExceptionHandlerFilter.setFilter(new AuthExceptionHandlerFilter(objectMapper));
+    authExceptionHandlerFilter.addUrlPatterns("/api/*");
+    authExceptionHandlerFilter.setOrder(1);
+    return authExceptionHandlerFilter;
+  }
+}

--- a/src/main/java/com/novelpark/domain/novel/Novel.java
+++ b/src/main/java/com/novelpark/domain/novel/Novel.java
@@ -1,0 +1,65 @@
+package com.novelpark.domain.novel;
+
+import com.novelpark.domain.AuditingFields;
+import java.util.Objects;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.annotations.DynamicInsert;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@DynamicInsert
+@Table(name = "novel")
+@Entity
+public class Novel extends AuditingFields {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(length = 100, nullable = false)
+  private String title;
+
+  @Column(length = 512, nullable = false)
+  private String coverImageUrl;
+
+  @Column(nullable = false)
+  @ColumnDefault("0")
+  private Integer views;
+
+  @Column(nullable = false)
+  @ColumnDefault("0")
+  private Integer recommend;
+
+  @Builder
+  public Novel(String title, String coverImageUrl) {
+    this.title = title;
+    this.coverImageUrl = coverImageUrl;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof Novel)) {
+      return false;
+    }
+    Novel novel = (Novel) o;
+    return Objects.equals(id, novel.id);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(id);
+  }
+}

--- a/src/main/java/com/novelpark/domain/novel/NovelRepository.java
+++ b/src/main/java/com/novelpark/domain/novel/NovelRepository.java
@@ -1,0 +1,7 @@
+package com.novelpark.domain.novel;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NovelRepository extends JpaRepository<Novel, Long> {
+  
+}

--- a/src/main/java/com/novelpark/exception/ErrorCode.java
+++ b/src/main/java/com/novelpark/exception/ErrorCode.java
@@ -13,6 +13,7 @@ public enum ErrorCode {
   NO_SESSION("세션이 존재하지 않습니다."),
   MAIL_AUTH_EXPIRED("인증 코드가 만료되었습니다."),
   WRONG_MAIL_AUTH("잘못된 인증 코드입니다."),
+  UNAUTHORIZED("인증되지 않은 사용자입니다."),
 
   // OAUTH
   OAUTH_PROVIDER_NOT_FOUND("해당 OAuth 제공자가 존재하지 않습니다."),

--- a/src/main/java/com/novelpark/exception/UnAuthorizedException.java
+++ b/src/main/java/com/novelpark/exception/UnAuthorizedException.java
@@ -1,0 +1,12 @@
+package com.novelpark.exception;
+
+public class UnAuthorizedException extends NovelParkException {
+
+  public UnAuthorizedException(ErrorCode errorCode, String message) {
+    super(errorCode, message);
+  }
+
+  public UnAuthorizedException(ErrorCode errorCode) {
+    super(errorCode);
+  }
+}

--- a/src/main/java/com/novelpark/presentation/NovelController.java
+++ b/src/main/java/com/novelpark/presentation/NovelController.java
@@ -1,0 +1,34 @@
+package com.novelpark.presentation;
+
+import com.novelpark.application.novel.NovelService;
+import com.novelpark.presentation.dto.request.novel.NovelRegisterRequest;
+import javax.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+@RequiredArgsConstructor
+@RequestMapping("/api/novels")
+@RestController
+public class NovelController {
+
+  private final NovelService novelService;
+
+  @PostMapping(consumes = {
+      MediaType.APPLICATION_JSON_VALUE,
+      MediaType.MULTIPART_FORM_DATA_VALUE
+  })
+  public ResponseEntity<Void> register(
+      @Valid @RequestPart NovelRegisterRequest request,
+      @RequestPart MultipartFile coverImage
+  ) {
+    novelService.register(request.getTitle(), coverImage);
+    return ResponseEntity.status(HttpStatus.CREATED).build();
+  }
+}

--- a/src/main/java/com/novelpark/presentation/dto/request/novel/NovelRegisterRequest.java
+++ b/src/main/java/com/novelpark/presentation/dto/request/novel/NovelRegisterRequest.java
@@ -1,0 +1,15 @@
+package com.novelpark.presentation.dto.request.novel;
+
+import javax.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class NovelRegisterRequest {
+
+  @NotBlank(message = "소설 제목은 빈 값이 들어올 수 없습니다.")
+  private String title;
+}

--- a/src/main/java/com/novelpark/presentation/filter/AuthExceptionHandlerFilter.java
+++ b/src/main/java/com/novelpark/presentation/filter/AuthExceptionHandlerFilter.java
@@ -1,0 +1,37 @@
+package com.novelpark.presentation.filter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.novelpark.exception.ErrorResponse;
+import com.novelpark.exception.UnAuthorizedException;
+import java.io.IOException;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@RequiredArgsConstructor
+public class AuthExceptionHandlerFilter extends OncePerRequestFilter {
+
+  private final ObjectMapper objectMapper;
+
+  @Override
+  protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+      FilterChain filterChain) throws ServletException, IOException {
+    try {
+      filterChain.doFilter(request, response);
+    } catch (UnAuthorizedException ex) {
+      setErrorResponse(response, ex);
+    }
+  }
+
+  private void setErrorResponse(HttpServletResponse response,
+      UnAuthorizedException ex) throws IOException {
+    response.setStatus(HttpStatus.UNAUTHORIZED.value());
+    response.setContentType("application/json;charset=UTF-8");
+    ErrorResponse errorResponse = ErrorResponse.from(ex);
+    response.getWriter().write(objectMapper.writeValueAsString(errorResponse));
+  }
+}

--- a/src/main/java/com/novelpark/presentation/filter/SessionFilter.java
+++ b/src/main/java/com/novelpark/presentation/filter/SessionFilter.java
@@ -16,7 +16,8 @@ import org.springframework.web.filter.OncePerRequestFilter;
 public class SessionFilter extends OncePerRequestFilter {
 
   private final AntPathMatcher pathMatcher = new AntPathMatcher();
-  private final List<String> excludeUrlPatterns = List.of("/api/login/**", "/api/signup");
+  private final List<String> excludeUrlPatterns =
+      List.of("/api/login/**", "/api/signup", "/api/id", "/api/password/reset/**");
 
   @Override
   protected boolean shouldNotFilter(HttpServletRequest request) {

--- a/src/main/java/com/novelpark/presentation/filter/SessionFilter.java
+++ b/src/main/java/com/novelpark/presentation/filter/SessionFilter.java
@@ -1,0 +1,44 @@
+package com.novelpark.presentation.filter;
+
+import com.novelpark.exception.ErrorCode;
+import com.novelpark.exception.UnAuthorizedException;
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.springframework.util.AntPathMatcher;
+import org.springframework.web.cors.CorsUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+public class SessionFilter extends OncePerRequestFilter {
+
+  private final AntPathMatcher pathMatcher = new AntPathMatcher();
+  private final List<String> excludeUrlPatterns = List.of("/api/login/**", "/api/signup");
+
+  @Override
+  protected boolean shouldNotFilter(HttpServletRequest request) {
+    return excludeUrlPatterns.stream()
+        .anyMatch(pattern -> pathMatcher.match(pattern, request.getRequestURI()));
+  }
+
+  @Override
+  protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+      FilterChain filterChain) throws ServletException, IOException {
+    if (CorsUtils.isPreFlightRequest(request)) {
+      filterChain.doFilter(request, response);
+      return;
+    }
+
+    verifyMemberIsLogin(request);
+
+    filterChain.doFilter(request, response);
+  }
+
+  private void verifyMemberIsLogin(HttpServletRequest request) {
+    Optional.ofNullable(request.getSession(false))
+        .orElseThrow(() -> new UnAuthorizedException(ErrorCode.UNAUTHORIZED));
+  }
+}

--- a/src/test/java/com/novelpark/DatabaseInitializerExtension.java
+++ b/src/test/java/com/novelpark/DatabaseInitializerExtension.java
@@ -1,0 +1,16 @@
+package com.novelpark;
+
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+public class DatabaseInitializerExtension implements AfterEachCallback {
+
+  @Override
+  public void afterEach(ExtensionContext context) throws Exception {
+    DatabaseInitializer databaseInitializer = (DatabaseInitializer) SpringExtension.getApplicationContext(
+            context)
+        .getBean("databaseInitializer");
+    databaseInitializer.truncateTables();
+  }
+}

--- a/src/test/java/com/novelpark/SupportRepository.java
+++ b/src/test/java/com/novelpark/SupportRepository.java
@@ -1,0 +1,23 @@
+package com.novelpark;
+
+import javax.persistence.EntityManager;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Profile("test")
+@Transactional
+@Component
+public class SupportRepository {
+
+  @Autowired
+  private EntityManager em;
+
+  public <T> T save(T entity) {
+    em.persist(entity);
+    em.flush();
+    em.clear();
+    return entity;
+  }
+}

--- a/src/test/java/com/novelpark/acceptance/AcceptanceTest.java
+++ b/src/test/java/com/novelpark/acceptance/AcceptanceTest.java
@@ -1,0 +1,18 @@
+package com.novelpark.acceptance;
+
+import com.novelpark.DatabaseInitializerExtension;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+@ExtendWith(DatabaseInitializerExtension.class)
+@SpringBootTest(webEnvironment = WebEnvironment.DEFINED_PORT)
+public @interface AcceptanceTest {
+
+}

--- a/src/test/java/com/novelpark/acceptance/AcceptanceTestSupport.java
+++ b/src/test/java/com/novelpark/acceptance/AcceptanceTestSupport.java
@@ -1,6 +1,7 @@
 package com.novelpark.acceptance;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.novelpark.SupportRepository;
 import com.novelpark.application.image.S3Uploader;
 import com.novelpark.application.mail.MailService;
 import java.io.File;
@@ -13,6 +14,8 @@ public abstract class AcceptanceTestSupport {
 
   @Autowired
   protected ObjectMapper objectMapper;
+  @Autowired
+  protected SupportRepository supportRepository;
 
   @MockBean
   protected S3Uploader s3Uploader;

--- a/src/test/java/com/novelpark/acceptance/AcceptanceTestSupport.java
+++ b/src/test/java/com/novelpark/acceptance/AcceptanceTestSupport.java
@@ -4,10 +4,16 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.novelpark.SupportRepository;
 import com.novelpark.application.image.S3Uploader;
 import com.novelpark.application.mail.MailService;
+import com.novelpark.domain.member.Member;
+import com.novelpark.domain.member.oauth.OAuthProvider;
+import com.novelpark.infrastructure.hash.PasswordEncoder;
+import io.restassured.RestAssured;
 import java.io.File;
 import java.io.IOException;
+import java.util.Map;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
 
 @AcceptanceTest
 public abstract class AcceptanceTestSupport {
@@ -16,13 +22,33 @@ public abstract class AcceptanceTestSupport {
   protected ObjectMapper objectMapper;
   @Autowired
   protected SupportRepository supportRepository;
-
   @MockBean
   protected S3Uploader s3Uploader;
   @MockBean
   protected MailService mailService;
+  @Autowired
+  private PasswordEncoder passwordEncoder;
 
   protected File createStubFile() throws IOException {
     return File.createTempFile("test", ".png");
+  }
+
+  protected String signupAndGetSession() {
+    supportRepository.save(Member.builder()
+        .name("jeongyong")
+        .email("23yong@naver.com")
+        .loginId("23yong")
+        .password(passwordEncoder.encrypt("asdf1234"))
+        .oAuthProvider(OAuthProvider.NAVER)
+        .profileUrl("url")
+        .build());
+
+    var sessionResponse = RestAssured.given()
+        .contentType(MediaType.APPLICATION_JSON_VALUE)
+        .body(Map.of("loginId", "23yong", "password", "asdf1234"))
+        .when()
+        .post("/api/login")
+        .then().extract();
+    return sessionResponse.sessionId();
   }
 }

--- a/src/test/java/com/novelpark/acceptance/AcceptanceTestSupport.java
+++ b/src/test/java/com/novelpark/acceptance/AcceptanceTestSupport.java
@@ -1,0 +1,25 @@
+package com.novelpark.acceptance;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.novelpark.application.image.S3Uploader;
+import com.novelpark.application.mail.MailService;
+import java.io.File;
+import java.io.IOException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+@AcceptanceTest
+public abstract class AcceptanceTestSupport {
+
+  @Autowired
+  protected ObjectMapper objectMapper;
+
+  @MockBean
+  protected S3Uploader s3Uploader;
+  @MockBean
+  protected MailService mailService;
+
+  protected File createStubFile() throws IOException {
+    return File.createTempFile("test", ".png");
+  }
+}

--- a/src/test/java/com/novelpark/acceptance/AuthAcceptanceTest.java
+++ b/src/test/java/com/novelpark/acceptance/AuthAcceptanceTest.java
@@ -6,57 +6,19 @@ import static org.mockito.BDDMockito.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willDoNothing;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.novelpark.DatabaseInitializer;
-import com.novelpark.application.image.S3Uploader;
-import com.novelpark.application.mail.MailService;
 import com.novelpark.domain.image.ImageFile;
 import com.novelpark.presentation.dto.request.auth.SignupRequest;
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import io.restassured.specification.RequestSpecification;
-import java.io.BufferedWriter;
 import java.io.File;
-import java.io.FileWriter;
-import java.io.IOException;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
-public class AuthAcceptanceTest {
-
-  @Autowired
-  private ObjectMapper objectMapper;
-
-  @Autowired
-  private DatabaseInitializer databaseInitializer;
-
-  @MockBean
-  private S3Uploader s3Uploader;
-  @MockBean
-  private MailService mailService;
-
-  @AfterEach
-  void tearDown() {
-    databaseInitializer.truncateTables();
-  }
-
-  private File createStubFile() throws IOException {
-    File stubFile = File.createTempFile("test", ".png");
-    try (BufferedWriter writer = new BufferedWriter(new FileWriter(stubFile))) {
-      writer.write("content");
-    } catch (IOException e) {
-      e.printStackTrace();
-    }
-    return stubFile;
-  }
+public class AuthAcceptanceTest extends AcceptanceTestSupport {
 
   @DisplayName("회원가입 할 때")
   @Nested

--- a/src/test/java/com/novelpark/acceptance/NovelAcceptanceTest.java
+++ b/src/test/java/com/novelpark/acceptance/NovelAcceptanceTest.java
@@ -5,24 +5,47 @@ import static org.mockito.BDDMockito.any;
 import static org.mockito.BDDMockito.given;
 
 import com.novelpark.domain.image.ImageFile;
+import com.novelpark.domain.member.Member;
+import com.novelpark.domain.member.oauth.OAuthProvider;
+import com.novelpark.infrastructure.hash.PasswordEncoder;
 import io.restassured.RestAssured;
 import java.io.IOException;
 import java.util.Map;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 
 public class NovelAcceptanceTest extends AcceptanceTestSupport {
+
+  @Autowired
+  private PasswordEncoder passwordEncoder;
 
   @DisplayName("소설 표지와 등록 정보가 주어지면 소설 등록에 성공한다.")
   @Test
   void givenNovelCoverImageAndRegisterData_whenRegisterNovel_thenSuccess() throws IOException {
     // given
     given(s3Uploader.uploadImageFile(any(ImageFile.class))).willReturn("url");
+    supportRepository.save(Member.builder()
+        .name("jeongyong")
+        .email("23yong@naver.com")
+        .loginId("23yong")
+        .password(passwordEncoder.encrypt("asdf1234"))
+        .oAuthProvider(OAuthProvider.NAVER)
+        .profileUrl("url")
+        .build());
+
+    var sessionResponse = RestAssured.given()
+        .contentType(MediaType.APPLICATION_JSON_VALUE)
+        .body(Map.of("loginId", "23yong", "password", "asdf1234"))
+        .when()
+        .post("/api/login")
+        .then().extract();
+    String session = sessionResponse.sessionId();
 
     var request = RestAssured
         .given().log().all()
-        .sessionId("memberSeq", "1")
+        .sessionId(session)
         .contentType(MediaType.MULTIPART_FORM_DATA_VALUE)
         .multiPart("request",
             Map.of("title", "던전에서 만남을 추구하면 안되는 걸까?"),

--- a/src/test/java/com/novelpark/acceptance/NovelAcceptanceTest.java
+++ b/src/test/java/com/novelpark/acceptance/NovelAcceptanceTest.java
@@ -5,43 +5,21 @@ import static org.mockito.BDDMockito.any;
 import static org.mockito.BDDMockito.given;
 
 import com.novelpark.domain.image.ImageFile;
-import com.novelpark.domain.member.Member;
-import com.novelpark.domain.member.oauth.OAuthProvider;
-import com.novelpark.infrastructure.hash.PasswordEncoder;
 import io.restassured.RestAssured;
 import java.io.IOException;
 import java.util.Map;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 
 public class NovelAcceptanceTest extends AcceptanceTestSupport {
-
-  @Autowired
-  private PasswordEncoder passwordEncoder;
 
   @DisplayName("소설 표지와 등록 정보가 주어지면 소설 등록에 성공한다.")
   @Test
   void givenNovelCoverImageAndRegisterData_whenRegisterNovel_thenSuccess() throws IOException {
     // given
     given(s3Uploader.uploadImageFile(any(ImageFile.class))).willReturn("url");
-    supportRepository.save(Member.builder()
-        .name("jeongyong")
-        .email("23yong@naver.com")
-        .loginId("23yong")
-        .password(passwordEncoder.encrypt("asdf1234"))
-        .oAuthProvider(OAuthProvider.NAVER)
-        .profileUrl("url")
-        .build());
-
-    var sessionResponse = RestAssured.given()
-        .contentType(MediaType.APPLICATION_JSON_VALUE)
-        .body(Map.of("loginId", "23yong", "password", "asdf1234"))
-        .when()
-        .post("/api/login")
-        .then().extract();
-    String session = sessionResponse.sessionId();
+    String session = signupAndGetSession();
 
     var request = RestAssured
         .given().log().all()

--- a/src/test/java/com/novelpark/acceptance/NovelAcceptanceTest.java
+++ b/src/test/java/com/novelpark/acceptance/NovelAcceptanceTest.java
@@ -1,0 +1,44 @@
+package com.novelpark.acceptance;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.any;
+import static org.mockito.BDDMockito.given;
+
+import com.novelpark.domain.image.ImageFile;
+import io.restassured.RestAssured;
+import java.io.IOException;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+
+public class NovelAcceptanceTest extends AcceptanceTestSupport {
+
+  @DisplayName("소설 표지와 등록 정보가 주어지면 소설 등록에 성공한다.")
+  @Test
+  void givenNovelCoverImageAndRegisterData_whenRegisterNovel_thenSuccess() throws IOException {
+    // given
+    given(s3Uploader.uploadImageFile(any(ImageFile.class))).willReturn("url");
+
+    var request = RestAssured
+        .given().log().all()
+        .sessionId("memberSeq", "1")
+        .contentType(MediaType.MULTIPART_FORM_DATA_VALUE)
+        .multiPart("request",
+            Map.of("title", "던전에서 만남을 추구하면 안되는 걸까?"),
+            MediaType.APPLICATION_JSON_VALUE)
+        .multiPart("coverImage",
+            createStubFile(),
+            MediaType.IMAGE_PNG_VALUE);
+
+    // when
+    var response = request
+        .when()
+        .post("/api/novels")
+        .then().log().all()
+        .extract();
+
+    // then
+    assertThat(response.statusCode()).isEqualTo(201);
+  }
+}


### PR DESCRIPTION
## Issues
- #19 

## 변경점
- 소설 등록 기능을 구현했습니다.
  - 소설 커버 이미지, 소설 제목이 요청으로 주어지면 등록이 되도록 했습니다.
- 테스트코드 
  - `@AcceptanceTest`을 사용해 독립된 테스트환경을 구축했습니다.

## 의문점
비밀번호 찾기는 로그인된 사용자가 아닌 것 같습니다. 따라서 검증 필터를 타지 않도록 했습니다.
그런데 `AuthController` 클래스의 `sendPasswordResetMail`메서드는 세션을 사용하고 있는 것 같습니다.
따라서 로직을 수정해야할 것 같습니다!